### PR TITLE
Fix channel join spam

### DIFF
--- a/script.js
+++ b/script.js
@@ -236,8 +236,13 @@ function connectToChannels() {
 	// Connection logging and stuff.
 	for(var i = 0; i < channels.length; i++) {
 		console.log(("Trying to connect to channels: " + channels[i].beam + " / " + channels[i].twitch).white);
-		twitch.join('#'+channels[i].twitch.toLowerCase());
-		console.log(("Connected to Twitch channel: " + channels[i].twitch).magenta);
+		//Don't call .join here, the connections array passed in the IRC constructor above will handle that
+		twitch.once("join#" + channels[i].twitch, function(i) {
+			console.log(("Connected to Twitch channel: " + channels[i].twitch).magenta);
+		}.bind(this, i));
+		//Do manually connect to beam though because it does require some extra lifting
+		//TODO: Beam might have rate limits, If so delay the execution of this method
+		//by x ms
 		connectChats({beam: channels[i].beam, twitch: channels[i].twitch});
 	}
 }


### PR DESCRIPTION
In the initial swap to WS for beam we had to move the code that logged connecting to channels to a function so that it would be called after the beam login.

Unfourtunately during that copy and paste we also lost the correct behaviour here, which is to listen to the join event ONCE on the twitch channel and then log it. 

The twitch irc connector will connect to all channels passed into its constructor options eventually at a suitable delay. 

Beam needs some lifting before we get into the channel. There may be some rate limiting here too. If so delay the execution of joinChannel by x MS.